### PR TITLE
fix xml.etree.ElementTree.Element.getiterator() method use

### DIFF
--- a/xdxf2slob/__init__.py
+++ b/xdxf2slob/__init__.py
@@ -148,7 +148,7 @@ class XDXF():
             tail = tail.lstrip()
             element.text = tail + element.text if element.text else tail
         self._transform_element(element, abbreviations)
-        for child in element.getiterator():
+        for child in element.iter():
             self._transform_element(child, abbreviations)
 
         txt = etree.tostring(element, encoding='unicode')


### PR DESCRIPTION
which was replaced by iter() in python-3.9
Fixes #5